### PR TITLE
Allow to install captain by major version lookup

### DIFF
--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./
-      - run: captain --version | grep '^v0\.'
+      - run: captain --version | grep '^v1\.'
 
   test_specific_version:
     runs-on: ubuntu-latest

--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -18,14 +18,21 @@ jobs:
           nix develop --command npm run build
           diff dist/index.old.$GITHUB_RUN_ID.$GITHUB_RUN_NUMBER.js dist/index.js
 
-  test:
-    name: Test
+  test_default_version:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
       - uses: ./
-      - run: captain --help
+      - run: captain --version | grep '^v0\.'
+
+  test_specific_version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./
+        with:
+          version: v0.8.0
+      - run: captain --version | grep '^v0\.8\.0$'
 
   lint:
     name: Lint

--- a/README.md
+++ b/README.md
@@ -6,12 +6,8 @@ This is a GitHub action for using setting up `captain` in your job.
 
 ### `version`
 
-The version of `captain` to install. Defaults to `v1`. Possible values are `v1`,
-`latest`, or a semantic version number.
-
-`latest` will look up the latest release across all major versions.
-
-`v1` refers to the latest release with major version 1, i.e. `v1.x.x`.
+The version of `captain` to install. Defaults to `v1` - alternatively, a
+semantic version number can be supplied as well (e.g. `v0.7.1`)
 
 ## Example usage
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,24 @@ This is a GitHub action for using setting up `captain` in your job.
 
 ### `version`
 
-The version of `captain` to install. Defaults to `latest`.
+The version of `captain` to install. Defaults to `v1`. Possible values are `v1`,
+`latest`, or a semantic version number.
+
+`latest` will look up the latest release across all major versions.
+
+`v1` refers to the latest release with major version 1, i.e. `v1.x.x`.
 
 ## Example usage
 
+### Recommended
+```yaml
+uses: rwx-research/setup-captain@v1
+```
+
+### Pinned to a specific CLI version
 ```yaml
 uses: rwx-research/setup-captain@v1
 with:
-  version: v0.6.1
+  version: 0.7.1
 ```
+

--- a/action.yaml
+++ b/action.yaml
@@ -5,7 +5,7 @@ inputs:
     description: |
       Version of the Captain CLI to install.
       Must either be "latest" or a semver identifier.
-    default: latest
+    default: v1
     required: false
 runs:
   using: 'node16'

--- a/dist/index.js
+++ b/dist/index.js
@@ -6575,7 +6575,7 @@ function run() {
         if (version === 'latest' || version === 'v1') {
             const versions = yield fetchVersionLookup();
             if (!versions.has(version)) {
-                throw 'Unknown version ${version}';
+                throw `Unknown version ${version}`;
             }
             version = versions.get(version);
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -6558,17 +6558,26 @@ const core = __nccwpck_require__(2186);
 const exec = __nccwpck_require__(1514);
 const http = __nccwpck_require__(6255);
 const tc = __nccwpck_require__(7784);
+function fetchVersionLookup() {
+    return __awaiter(this, void 0, void 0, function* () {
+        core.debug('Fetching list of Captain releases');
+        const client = new http.HttpClient();
+        const versions = yield client.getJson('https://releases.captain.build/versions.json');
+        if (versions.statusCode !== 200 || versions.result === null) {
+            throw 'Unable to fetch list of Captain releases';
+        }
+        return new Map(Object.entries(versions.result.captain));
+    });
+}
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         let version = core.getInput('version');
-        if (version === 'latest') {
-            core.debug('Fetching list of Captain releases');
-            const client = new http.HttpClient();
-            const versions = yield client.getJson('https://releases.captain.build/versions.json');
-            if (versions.statusCode !== 200 || versions.result === null) {
-                throw 'Unable to fetch list of Captain releases';
+        if (version === 'latest' || version === 'v1') {
+            const versions = yield fetchVersionLookup();
+            if (!versions.has(version)) {
+                throw 'Unknown version ${version}';
             }
-            version = versions.result.captain.latest;
+            version = versions.get(version);
         }
         let os = process.platform;
         if (os === 'win32') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-captain",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "This action installs the captain CLI in Github Actions",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ async function run() {
   if (version === 'latest' || version === 'v1') {
     const versions = await fetchVersionLookup()
     if (!versions.has(version)) {
-      throw 'Unknown version ${version}'
+      throw `Unknown version ${version}`
     }
 
     version = versions.get(version) as string


### PR DESCRIPTION
This change allows a user to install the latest `v1.x.x` version of the CLI by referring to it as `v1`. Also, this is now the new default when no version number was supplied. Explicitly setting `latest` as the version number continues to work.

> **Warning**: This is currently broken and should not be merged until we actually have a `v1` version of the CLI released.

Further, this technically constitutes a breaking change to the public API of this action and would require a major version change as we follow semantic versioning. However, the main motivation behind changing the default behaviour was to align the `v1` version of this action with the `v1` release of the CLI, so a major version bump would defeat the purpose here.