### PR TITLE
Output the version after installing

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6592,6 +6592,14 @@ function run() {
         const captain = yield tc.downloadTool(url);
         core.debug('Installing to /usr/local/bin/captain');
         yield exec.exec('install', [captain, '/usr/local/bin/captain']);
+        const { stdout } = yield exec.getExecOutput('captain', ['--version'], {
+            silent: true
+        });
+        const cliVersion = stdout.replace('\n', '');
+        if (cliVersion !== version) {
+            throw `Unexpected version of Captain installed. Expected ${version} but installed ${cliVersion}`;
+        }
+        core.info(`captain ${cliVersion} is installed`);
     });
 }
 run().catch(err => core.setFailed(err));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-captain",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "This action installs the captain CLI in Github Actions",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,6 @@ import * as core from '@actions/core'
 import * as exec from '@actions/exec'
 import * as http from '@actions/http-client'
 import * as tc from '@actions/tool-cache'
-import * as path from 'path'
 
 interface ProductVersions {
   captain: Versions
@@ -56,6 +55,15 @@ async function run() {
 
   core.debug('Installing to /usr/local/bin/captain')
   await exec.exec('install', [captain, '/usr/local/bin/captain'])
+
+  const {stdout} = await exec.getExecOutput('captain', ['--version'], {
+    silent: true
+  })
+  const cliVersion = stdout.replace('\n', '')
+  if (cliVersion !== version) {
+    throw `Unexpected version of Captain installed. Expected ${version} but installed ${cliVersion}`
+  }
+  core.info(`captain ${cliVersion} is installed`)
 }
 
 run().catch(err => core.setFailed(err))


### PR DESCRIPTION
This will make debugging with customers easier. I also believe that having the action output something about its success helps give confidence that things are working as expected.