### PR TITLE
Make the v prefix on version numbers optional

### DIFF
--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -34,6 +34,15 @@ jobs:
           version: v0.8.0
       - run: captain --version | grep '^v0\.8\.0$'
 
+  test_specific_version_without_v_prefix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./
+        with:
+          version: 1.0.57
+      - run: captain --version | grep '^v1\.0\.57$'
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/dist/index.js
+++ b/dist/index.js
@@ -6579,6 +6579,9 @@ function run() {
             }
             version = versions.get(version);
         }
+        if (version.match(/^[0-9]+/)) {
+            version = `v${version}`;
+        }
         let os = process.platform;
         if (os === 'win32') {
             os = 'windows';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-captain",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "This action installs the captain CLI in Github Actions",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,9 @@ async function run() {
 
     version = versions.get(version) as string
   }
+  if (version.match(/^[0-9]+/)) {
+    version = `v${version}`
+  }
 
   let os = process.platform as string
   if (os === 'win32') {


### PR DESCRIPTION
I accidentally omitted the `v` when using `setup-captain` and got a cryptic `403` error.

```
Error: Error: Unexpected HTTP response: 403
```

I thought this might be an easy mistake to make, and we also made the mistake in our [documentation in the README](https://github.com/rwx-research/setup-captain/blob/2d90234094c1ca437bb2b052e85461bb2567ce6a/README.md), so I thought we should update this to prepend the `v` when it's omitted.