### PR TITLE
Make latest an alias to v1 to deprecate and remove it

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6572,7 +6572,10 @@ function fetchVersionLookup() {
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         let version = core.getInput('version');
-        if (version === 'latest' || version === 'v1') {
+        if (version === 'latest') {
+            version = 'v1';
+        }
+        if (version === 'v1') {
             const versions = yield fetchVersionLookup();
             if (!versions.has(version)) {
                 throw `Unknown version ${version}`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setup-captain",
-  "version": "1.1.2",
+  "version": "1.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-captain",
-      "version": "1.1.2",
+      "version": "1.1.5",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-captain",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "This action installs the captain CLI in Github Actions",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ interface ProductVersions {
 }
 
 interface Versions {
-  latest: string
+  v1: string
   versions: string[]
 }
 
@@ -29,7 +29,11 @@ async function fetchVersionLookup(): Promise<Map<string, string>> {
 
 async function run() {
   let version = core.getInput('version')
-  if (version === 'latest' || version === 'v1') {
+  if (version === 'latest') {
+    version = 'v1'
+  }
+
+  if (version === 'v1') {
     const versions = await fetchVersionLookup()
     if (!versions.has(version)) {
       throw `Unknown version ${version}`


### PR DESCRIPTION
In support of the work to expose -v1 binaries statically, this removes (but aliases it to v1, just in case) latest. In practice, our docs indicated this wasn't an option anyway, so this shouldn't have much (any?) impact.