### PR TITLE
Fetch the -v1 url instead of doing the version lookup

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6556,31 +6556,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const core = __nccwpck_require__(2186);
 const exec = __nccwpck_require__(1514);
-const http = __nccwpck_require__(6255);
 const tc = __nccwpck_require__(7784);
-function fetchVersionLookup() {
-    return __awaiter(this, void 0, void 0, function* () {
-        core.debug('Fetching list of Captain releases');
-        const client = new http.HttpClient();
-        const versions = yield client.getJson('https://releases.captain.build/versions.json');
-        if (versions.statusCode !== 200 || versions.result === null) {
-            throw 'Unable to fetch list of Captain releases';
-        }
-        return new Map(Object.entries(versions.result.captain));
-    });
-}
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         let version = core.getInput('version');
         if (version === 'latest') {
             version = 'v1';
-        }
-        if (version === 'v1') {
-            const versions = yield fetchVersionLookup();
-            if (!versions.has(version)) {
-                throw `Unknown version ${version}`;
-            }
-            version = versions.get(version);
         }
         if (version.match(/^[0-9]+/)) {
             version = `v${version}`;
@@ -6602,7 +6583,7 @@ function run() {
             silent: true
         });
         const cliVersion = stdout.replace('\n', '');
-        if (cliVersion !== version) {
+        if (cliVersion !== version && version !== 'v1') {
             throw `Unexpected version of Captain installed. Expected ${version} but installed ${cliVersion}`;
         }
         core.info(`captain ${cliVersion} is installed`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setup-captain",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-captain",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-captain",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "This action installs the captain CLI in Github Actions",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Now that we're publishing the -v1 binaries directly, we can simply download those.