### PR TITLE
Change download URL to use Github releases

### DIFF
--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -31,8 +31,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./
         with:
-          version: v0.8.0
-      - run: captain --version | grep '^v0\.8\.0$'
+          version: v1.9.11
+      - run: captain --version | grep '^v1\.9\.11$'
 
   test_specific_version_without_v_prefix:
     runs-on: ubuntu-latest
@@ -40,8 +40,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./
         with:
-          version: 1.0.57
-      - run: captain --version | grep '^v1\.0\.57$'
+          version: 1.9.11
+      - run: captain --version | grep '^v1\.9\.11$'
 
   lint:
     name: Lint

--- a/dist/index.js
+++ b/dist/index.js
@@ -6579,7 +6579,7 @@ function run() {
         else if (arch === 'arm64') {
             arch = 'aarch64';
         }
-        const url = `https://releases.captain.build/${version}/${os}/${arch}/captain${extension}`;
+        const url = `https://github.com/rwx-research/captain/releases/download/${version}/captain-${os}-${arch}${extension}`;
         core.debug(`Fetching ${url}`);
         const captain = yield tc.downloadTool(url);
         core.debug('Installing to /usr/local/bin/captain');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setup-captain",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-captain",
-      "version": "1.1.7",
+      "version": "1.1.8",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-captain",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "This action installs the captain CLI in Github Actions",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ async function run() {
     arch = 'aarch64'
   }
 
-  const url = `https://releases.captain.build/${version}/${os}/${arch}/captain${extension}`
+  const url = `https://github.com/rwx-research/captain/releases/download/${version}/captain-${os}-${arch}${extension}`
 
   core.debug(`Fetching ${url}`)
   const captain = await tc.downloadTool(url)


### PR DESCRIPTION
With this PR, the action will be using the assets from https://github.com/rwx-research/captain/releases