### PR TITLE
Update action to run with node 20

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -13,5 +13,5 @@ inputs:
     default: v1
     required: false
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setup-captain",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-captain",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",
@@ -15,10 +15,13 @@
         "@actions/tool-cache": "^2.0.1"
       },
       "devDependencies": {
-        "@types/node": "^18.11.6",
+        "@types/node": "^20.11.10",
         "@vercel/ncc": "^0.34.0",
         "prettier": "^2.7.1",
         "typescript": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/@actions/core": {
@@ -74,10 +77,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.11.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.6.tgz",
-      "integrity": "sha512-j3CEDa2vd96K0AXF8Wur7UucACvnjkk8hYyQAHhUNciabZLDl9nfAEVUSwmh245OOZV15bRA3Y590Gi5jUcDJg==",
-      "dev": true
+      "version": "20.11.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.10.tgz",
+      "integrity": "sha512-rZEfe/hJSGYmdfX9tvcPMYeYPW2sNl50nsw4jZmRcaG0HIAb0WYEpsB05GOb53vjqpyE9GUhlDQ4jLSoB5q9kg==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@vercel/ncc": {
       "version": "0.34.0",
@@ -131,6 +137,12 @@
       "engines": {
         "node": ">=4.2.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/uuid": {
       "version": "8.3.2",
@@ -193,10 +205,13 @@
       }
     },
     "@types/node": {
-      "version": "18.11.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.6.tgz",
-      "integrity": "sha512-j3CEDa2vd96K0AXF8Wur7UucACvnjkk8hYyQAHhUNciabZLDl9nfAEVUSwmh245OOZV15bRA3Y590Gi5jUcDJg==",
-      "dev": true
+      "version": "20.11.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.10.tgz",
+      "integrity": "sha512-rZEfe/hJSGYmdfX9tvcPMYeYPW2sNl50nsw4jZmRcaG0HIAb0WYEpsB05GOb53vjqpyE9GUhlDQ4jLSoB5q9kg==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@vercel/ncc": {
       "version": "0.34.0",
@@ -224,6 +239,12 @@
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
       "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
     "uuid": {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,11 @@
   },
   "author": "rwx",
   "license": "MIT",
+  "engines": {
+    "node": ">= 20"
+  },
   "devDependencies": {
-    "@types/node": "^18.11.6",
+    "@types/node": "^20.11.10",
     "@vercel/ncc": "^0.34.0",
     "prettier": "^2.7.1",
     "typescript": "^4.8.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-captain",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "This action installs the captain CLI in Github Actions",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
GitHub has deprecated Node 16 in Actions. Workflows using this action are throwing a deprecation warning since it's using Node 16

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20